### PR TITLE
LL-4393 replace experimental button by beta

### DIFF
--- a/src/renderer/components/MainSideBar/index.js
+++ b/src/renderer/components/MainSideBar/index.js
@@ -14,8 +14,6 @@ import { isNavigationLocked } from "~/renderer/reducers/application";
 import { openModal } from "~/renderer/actions/modals";
 import { setFirstTimeLend, setSidebarCollapsed } from "~/renderer/actions/settings";
 
-import useExperimental from "~/renderer/hooks/useExperimental";
-
 import { darken, rgba } from "~/renderer/styles/helpers";
 
 import IconManager from "~/renderer/icons/Manager";
@@ -35,7 +33,6 @@ import Space from "~/renderer/components/Space";
 import UpdateDot from "~/renderer/components/Updater/UpdateDot";
 import { Dot } from "~/renderer/components/Dot";
 import Stars from "~/renderer/components/Stars";
-import useEnv from "~/renderer/hooks/useEnv";
 
 import TopGradient from "./TopGradient";
 import Hide from "./Hide";
@@ -160,20 +157,21 @@ const SideBar = styled(Box).attrs(() => ({
 `;
 
 const TagContainer = ({ collapsed }: { collapsed: boolean }) => {
-  const isExperimental = useExperimental();
-  const hasFullNodeConfigured = useEnv("SATSTACK"); // NB remove once full node is not experimental
-
   const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const currentVersion = __APP_VERSION__;
 
-  return isExperimental || hasFullNodeConfigured ? (
-    <Tag
-      id="drawer-experimental-button"
-      to={{ pathname: "/settings/experimental", state: { source: "sidebar" } }}
-    >
+  const openReleaseNotesModal = useCallback(
+    () => dispatch(openModal("MODAL_RELEASE_NOTES", currentVersion)),
+    [currentVersion, dispatch],
+  );
+
+  return (
+    <Tag id="drawer-experimental-button" onClick={openReleaseNotesModal}>
       <IconExperimental width={16} height={16} />
-      <TagText collapsed={collapsed}>{t("common.experimentalFeature")}</TagText>
+      <TagText collapsed={collapsed}>{t("common.beta")}</TagText>
     </Tag>
-  ) : null;
+  );
 };
 
 const MainSideBar = () => {

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -51,6 +51,7 @@
     "addressCopied": "Address copied",
     "addressCopiedSuspicious": "Mismatch between the copied address and the one in the clipboard.",
     "experimentalFeature": "Experimental",
+    "beta": "Beta",
     "dismiss": "Dismiss",
     "information": "Information",
     "search": "Search...",


### PR DESCRIPTION
Replace "experimental" indicator byt "beta" and open release notes when clicking on it

### Type

Feature

### Context

LL-4393

### Parts of the app affected / Test plan

Sidebar

![image](https://user-images.githubusercontent.com/671786/105834993-8045f400-5fcb-11eb-8ae3-813f3428669f.png)
